### PR TITLE
ci: add nx cloud token for pre publish pipeline

### DIFF
--- a/.github/workflows/publish-pre.yml
+++ b/.github/workflows/publish-pre.yml
@@ -11,6 +11,7 @@ on:
 env:
   # NX release needs to have a GH token in env.GITHUB_TOKEN
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
 jobs:
   publish:


### PR DESCRIPTION
Pre publish workflows fail.
I assume bc of missing nx cloud token